### PR TITLE
Bump version to 0.1.50 and update cchain to 0.3.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "you"
-version = "0.1.42"
+version = "0.1.50"
 edition = "2024"
 description = "Translate your natural language into executable command(s)"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0.97"
 async-openai = "0.28.0"
-cchain = "0.3.3"
+cchain = "0.3.42"
 chrono = "0.4.40"
 clap = { version = "4.5.31", features = ["derive"] }
 indicatif = "0.17.11"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, Error};
-use cchain::{commons::utility::input_message, display_control::{display_message, Level}};
+use cchain::{commons::utility::input_message, core::program::Program, display_control::{display_message, Level}};
 use indicatif::ProgressBar;
 
 use crate::{agent::{CommandJSON, Executable, SemiAutonomousCommandLineAgent, Step}, llm::Context, styles::start_spinner};
@@ -42,6 +42,14 @@ pub fn process_run_with_one_single_instruction(command_in_natural_language: &str
             match agent.execute(&mut command_json) {
                 Ok(_) => {
                     display_message(Level::Logging, "Commands had been executed successfully.");
+                    
+                    // Prompt the user for saving the command 
+                    let save_chain_input: String = input_message("Would you like to save the command to a chain? (n for no, type anything to name the chain)")?;
+                    if save_chain_input.trim() == "n" {
+                        break;
+                    }
+                    
+                    save_to_chain(save_chain_input.trim(), &mut vec![command_json])?;
                     break;
                 },
                 Err(error) => {
@@ -57,6 +65,7 @@ pub fn process_run_with_one_single_instruction(command_in_natural_language: &str
 pub fn process_interactive_mode() -> Result<(), Error> {
     let mut agent = SemiAutonomousCommandLineAgent::new()?;
     
+    let mut commands: Vec<CommandJSON> = Vec::new();
     let mut user_query: String = input_message("Yes, boss. What can I do for you:")?;
     loop {
         // Initialize an empty vector to store command lines
@@ -83,8 +92,31 @@ pub fn process_interactive_mode() -> Result<(), Error> {
         if user_query.trim() == "y" {
             match agent.execute(&mut command_json) {
                 Ok(_) => {
+                    // Store the command
+                    commands.push(command_json);
+                    
                     display_message(Level::Logging, "Commands had been executed successfully.");
-                    user_query = input_message("Boss, what else can I do for you:")?;
+                    
+                    user_query = input_message("Boss, what else can I do for you (type to instruct, e to exit, or enter w to save the commands so far):")?;
+                    
+                    if user_query.trim() == "e" {
+                        break;
+                    }
+                    
+                    if user_query.trim() == "w" {
+                        let name: String = input_message("Name of the chain:")?;
+                        save_to_chain(name.trim(), &mut commands)?;
+                        
+                        let user_feedback: String = input_message("Continue? (y for yes, e for exit):")?;
+                        
+                        if user_feedback.trim() == "e" {
+                            break;
+                        }
+                        
+                        if user_feedback.trim() == "y" {
+                            user_query = input_message("Boss, what else can I do for you (type to instruct):")?;
+                        }
+                    }
                 },
                 Err(error) => {
                     display_message(Level::Error, &error.to_string());
@@ -97,6 +129,35 @@ pub fn process_interactive_mode() -> Result<(), Error> {
             break;
         }
     }
+    
+    Ok(())
+}
+
+fn save_to_chain(chain_name: &str, commands: &mut Vec<CommandJSON>) -> Result<(), Error> {
+    let mut chain: Vec<Program> = Vec::new();
+    
+    for command in commands.iter_mut() {
+        let program = Program::new(
+            command.command.get_command().to_string(), 
+            command.command.get_arguments().to_owned(), 
+            None, 
+            None, 
+            None, 
+            Default::default(), 
+            None, 
+            Default::default(), 
+            None, 
+            0
+        );
+        
+        chain.push(program);
+    }
+    
+    let filepath: &str = &format!("./cchain_{}.json", chain_name);
+    let serialized_chain: String = serde_json::to_string_pretty(&chain)?;
+    std::fs::write(filepath, serialized_chain)?;
+    
+    display_message(Level::Logging, &format!("Chain had been saved to {}.", filepath));
     
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Error> {
         Commands::Run(subcommand) => {
             if let Some(command_in_natural_language) = subcommand.command_in_natural_language {
                 process_run_with_one_single_instruction(&command_in_natural_language)?;
+                return Ok(());
             }
             
             process_interactive_mode()?;


### PR DESCRIPTION
Add chain saving functionality for commands

- Save commands to named chains in both single instruction and interactive modes
- Prompt user to save commands after execution
- Store commands as serialized JSON files
- Add exit and save options to interactive mode