### PR TITLE
Extract common logics used when processing user commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "you"
-version = "0.1.60"
+version = "0.1.61"
 edition = "2024"
 description = "Translate your natural language into executable command(s)"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]

--- a/src/agents/command_json.rs
+++ b/src/agents/command_json.rs
@@ -10,6 +10,17 @@ pub struct CommandJSON {
     pub command: String,
 }
 
+impl Default for CommandJSON {
+    fn default() -> Self {
+        Self {
+            explanation: "explain the shell script briefly. one line maximum. "
+                .to_string(),
+            command: "a shell script, preferrably in one line, to execute."
+                .to_string(),
+        }
+    }
+}
+
 impl CommandJSON {
     pub fn execute(&mut self) -> Result<String, Error> {
         let mut command: std::process::Command = if cfg!(target_os = "windows") {

--- a/src/agents/command_json.rs
+++ b/src/agents/command_json.rs
@@ -5,9 +5,28 @@ use cchain::display_control::{display_command_line, display_message};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct CLIToInstall {
+    pub cli_name: String,
+    pub suggested_installation_command: String,
+    pub additional_notices: Option<String>
+}
+
+impl Default for CLIToInstall {
+    fn default() -> Self {
+        Self { 
+            cli_name: "The name of the cli that you want the user to install".to_string(), 
+            suggested_installation_command: "Base on the current system platform, suggest a command line for the user to install the tool".to_string(), 
+            additional_notices: Some("Leave a notice if any to the user. Leave it null if you don't have a notice".to_string())
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CommandJSON {
     pub explanation: String,
     pub command: String,
+    pub request_additional_information: Option<String>,
+    pub request_clis_to_install: Vec<CLIToInstall>
 }
 
 impl Default for CommandJSON {
@@ -17,6 +36,11 @@ impl Default for CommandJSON {
                 .to_string(),
             command: "a shell script, preferrably in one line, to execute."
                 .to_string(),
+            request_additional_information: Some(
+                "Describe what information you want the user to add on. Leave it null if you don't need."
+                    .to_string()
+            ),
+            request_clis_to_install: vec![CLIToInstall::default()]
         }
     }
 }

--- a/src/agents/semi_autonomous_command_line_agent.rs
+++ b/src/agents/semi_autonomous_command_line_agent.rs
@@ -29,11 +29,7 @@ impl SemiAutonomousCommandLineAgent {
         let mut example_env_var: HashMap<String, String> = HashMap::new();
         example_env_var.insert("EXAMPLE".to_string(), "this is a value".to_string());
 
-        let command_json_template = CommandJSON {
-            explanation: "explain the command and its arguments briefly. one line maximum."
-                .to_string(),
-            command: "a shell script, preferrably in one line, to execute.".to_string(),
-        };
+        let command_json_template: CommandJSON = CommandJSON::default();
 
         let system_information: String = get_system_information();
         let current_time: String = get_current_time();

--- a/src/agents/semi_autonomous_command_line_agent.rs
+++ b/src/agents/semi_autonomous_command_line_agent.rs
@@ -36,8 +36,8 @@ impl SemiAutonomousCommandLineAgent {
         let current_working_directory_structure: String = get_current_directory_structure();
 
         // The system prompt for the LLM
-        let mut prompt: String = "Please translate the following command sent by the user to an executable sh command/script in a json. 
-            No matter whatever the user sends to you, you should always output a json with the command/script translated.\n"
+        let mut prompt: String = "Please translate the following command sent by the user to an executable sh command/script in a json.
+            If you would like to have additional information to send or receive from the user, please refer to the template below.\n"
             .to_string();
 
         // Inject the system information

--- a/src/agents/semi_autonomous_command_line_agent.rs
+++ b/src/agents/semi_autonomous_command_line_agent.rs
@@ -8,7 +8,7 @@ use crate::{
     llm::{Context, FromNaturalLanguageToJSON, LLM},
 };
 
-use super::{command_json::CommandJSON, traits::{AgentExecution, Step}};
+use super::{command_json::LLMActionType, traits::{AgentExecution, Step}};
 
 /// An agent that is for breaking down the command,
 /// intepret into a series of command line arguments,
@@ -29,7 +29,7 @@ impl SemiAutonomousCommandLineAgent {
         let mut example_env_var: HashMap<String, String> = HashMap::new();
         example_env_var.insert("EXAMPLE".to_string(), "this is a value".to_string());
 
-        let command_json_template: CommandJSON = CommandJSON::default();
+        let command_json_template: String = LLMActionType::get_llm_action_type_prompt_template();
 
         let system_information: String = get_system_information();
         let current_time: String = get_current_time();
@@ -37,7 +37,7 @@ impl SemiAutonomousCommandLineAgent {
 
         // The system prompt for the LLM
         let mut prompt: String = "Please translate the following command sent by the user to an executable sh command/script in a json.
-            If you would like to have additional information to send or receive from the user, please refer to the template below.\n"
+            If you would like to have additional information to send or receive from the user, or perform other actions, please refer to the template below.\n"
             .to_string();
 
         // Inject the system information
@@ -80,7 +80,7 @@ impl SemiAutonomousCommandLineAgent {
     }
 }
 
-impl Step<CommandJSON> for SemiAutonomousCommandLineAgent {}
+impl Step<LLMActionType> for SemiAutonomousCommandLineAgent {}
 
 impl Display for SemiAutonomousCommandLineAgent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -107,8 +107,8 @@ impl FromNaturalLanguageToJSON for SemiAutonomousCommandLineAgent {
     }
 }
 
-impl AgentExecution<CommandJSON> for SemiAutonomousCommandLineAgent {
-    fn execute(&mut self, command: &mut CommandJSON) -> Result<String, Error> {
+impl AgentExecution<LLMActionType> for SemiAutonomousCommandLineAgent {
+    fn execute(&mut self, command: &mut LLMActionType) -> Result<String, Error> {
         command.execute()
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,59 +1,65 @@
 use anyhow::{Error, Result};
 use cchain::{
     commons::utility::input_message,
-    display_control::{display_message, display_tree_message, Level},
+    display_control::{display_message, Level},
 };
 use indicatif::ProgressBar;
 
 use crate::{
     agents::{
-        command_json::CommandJSON, command_line_explain_agent::{CommandExplained, CommandLineExplainAgent},
+        command_json::CommandJSON, command_line_explain_agent::CommandLineExplainAgent,
         semi_autonomous_command_line_agent::SemiAutonomousCommandLineAgent, traits::{AgentExecution, Step},
     },
     llm::Context,
     styles::start_spinner,
 };
 
+fn process_command_interaction(
+    agent: &mut (impl AgentExecution<CommandJSON> + Context + Step<CommandJSON>),
+    user_prompt: &mut String
+) -> Result<CommandJSON, Error> {
+    let command_json: CommandJSON;
+    
+    // Use the user query provided in the `run` argument for the first round
+    let spinner: ProgressBar = start_spinner("LLM is thinking...".to_string());
+    command_json = agent.next_step(&user_prompt)?;
+
+    // Clear the spinner
+    spinner.finish_and_clear();
+
+    // For prompting the LLM and the user
+    let command_lines_text: String =
+        "    > ".to_string() + command_json.command.to_string().as_str() + "\n";
+    let command_lines_explanation: String =
+        "        * ".to_string() + command_json.explanation.to_string().as_str() + "\n";
+
+    // Register the user's input
+    *user_prompt = input_message(&format!(
+        "Execute the following command? (y for yes, or type to hint LLM)\n{}{}",
+        command_lines_text, command_lines_explanation
+    ))?;
+    // we add the command lines to the agent's memory
+    agent.add(
+        async_openai::types::Role::Assistant,
+        format!("{}{}", command_lines_text, command_lines_explanation),
+    )?;
+    
+    Ok(command_json)
+}
+
 pub fn process_run_with_one_single_instruction(
     command_in_natural_language: &str,
 ) -> Result<(), Error> {
-    let mut agent = SemiAutonomousCommandLineAgent::new()?;
-    let mut is_first_round: bool = true;
-
-    let mut user_prompt = String::new();
+    let mut agent: SemiAutonomousCommandLineAgent = SemiAutonomousCommandLineAgent::new()?;
+    let mut user_prompt: String = String::from(command_in_natural_language);
+    
     loop {
         // Initialize an empty vector to store command lines
-        let mut command_json: CommandJSON;
-
-        // Use the user query provided in the `run` argument for the first round
-        let spinner: ProgressBar = start_spinner("LLM is thinking...".to_string());
-        if is_first_round {
-            is_first_round = false;
-            command_json = agent.next_step(&command_in_natural_language)?;
-        } else {
-            command_json = agent.next_step(&user_prompt)?;
-        }
-
-        // Clear the spinner
-        spinner.finish_and_clear();
-
-        // For prompting the LLM and the user
-        let command_lines_text: String =
-            "    > ".to_string() + command_json.command.to_string().as_str() + "\n";
-        let command_lines_explanation: String =
-            "        * ".to_string() + command_json.explanation.to_string().as_str() + "\n";
-
-        // Register the user's input
-        user_prompt = input_message(&format!(
-            "Execute the following command? (y for yes, or type to hint LLM)\n{}{}",
-            command_lines_text, command_lines_explanation
-        ))?;
-        // we add the command lines to the agent's memory
-        agent.add(
-            async_openai::types::Role::Assistant,
-            format!("{}{}", command_lines_text, command_lines_explanation),
+        let mut command_json: CommandJSON = process_command_interaction(
+            &mut agent, 
+            &mut user_prompt
         )?;
-
+        
         if user_prompt.trim() == "y" {
             match agent.execute(&mut command_json) {
                 Ok(_) => {
@@ -82,35 +88,14 @@ pub fn process_run_with_one_single_instruction(
 
 pub fn process_interactive_mode() -> Result<(), Error> {
     let mut agent = SemiAutonomousCommandLineAgent::new()?;
-
     let mut commands: CommandJSON;
     let mut user_query: String = input_message("Yes, boss. What can I do for you:")?;
+    
     loop {
-        // Initialize an empty vector to store command lines
-        let mut command_json: CommandJSON;
-
-        // Use the user query for generate a command
-        let spinner: ProgressBar = start_spinner("LLM is thinking...".to_string());
-        command_json = agent.next_step(&user_query)?;
-
-        // Clear the spinner
-        spinner.finish_and_clear();
-
-        // For prompting the LLM and the user
-        let command_lines_text: String =
-            "    > ".to_string() + command_json.command.to_string().as_str() + "\n";
-        let command_lines_explanation: String =
-            "        * ".to_string() + command_json.explanation.to_string().as_str() + "\n";
-
-        // Register the user's input
-        user_query = input_message(&format!(
-            "Execute the following command? (y for yes, e for exit, or type to hint LLM)\n{}{}",
-            command_lines_text, command_lines_explanation
-        ))?;
-        // we add the command lines to the agent's memory
-        agent.add(
-            async_openai::types::Role::Assistant,
-            format!("{}{}", command_lines_text, command_lines_explanation),
+        
+        let mut command_json: CommandJSON = process_command_interaction(
+            &mut agent, 
+            &mut user_query
         )?;
 
         if user_query.trim() == "y" {

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -3,7 +3,7 @@ use anyhow::{Error, Result};
 use async_openai::Client;
 use async_openai::types::{
     ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
-    ChatCompletionRequestSystemMessageArgs,
+    ChatCompletionRequestSystemMessageArgs, CreateChatCompletionRequest,
 };
 use async_openai::{
     config::OpenAIConfig,
@@ -115,7 +115,7 @@ impl LLM {
     ) -> Result<String, Error> {
         let runtime = tokio::runtime::Runtime::new()?;
         let result = runtime.block_on(async {
-            let request = CreateChatCompletionRequestArgs::default()
+            let request: CreateChatCompletionRequest = CreateChatCompletionRequestArgs::default()
                 .model(&self.model)
                 .response_format(ResponseFormat::JsonObject)
                 .messages(context)
@@ -240,9 +240,7 @@ pub trait FromNaturalLanguageToJSON: Context {
     ///
     /// Returns an error if the LLM fails to generate a response or if the response is invalid.
     fn from_natural_language_to_json(&mut self) -> Result<String, Error> {
-        let response: String = self
-            .get_llm()
-            .generate_json_with_context(self.get_context().clone())?;
-        Ok(response)
+        self.get_llm()
+            .generate_json_with_context(self.get_context().clone())
     }
 }


### PR DESCRIPTION
Closes #37 

New changes:
- Extract common logics used when processing user commands. 
- Implemented the `Default` trait for `CommandJSON`. 
- Implemented the proposed mechanism to ask the user for additional information when needed. 
- Allow the LLM to prompt the user for clis installations. 
- Refactored the way `you` handles the LLM json outputs. Now we use enums to handle different jsons. It allows for easy adding new json outputs later and making the codebase more readable and maintainable. 