### PR TITLE
Use `surfing` for json extractions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "you"
-version = "0.1.63"
+version = "0.1.64"
 edition = "2024"
 description = "Translate your natural language into executable command(s)"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ console = "0.15.11"
 indicatif = "0.17.11"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+surfing = "0.1.1"
 sysinfo = "0.33.1"
 tokio = { version = "1.44.0", features = ["rt", "rt-multi-thread"] }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -71,7 +71,7 @@ pub fn process_run_with_one_single_instruction(
 
                     // Prompt the user for saving the command
                     let save_shell_input: String = input_message(
-                        "Would you like to save the command to a chain? (n for no, type anything to name the chain)",
+                        "Would you like to save the command to a shell script? (n for no, type anything to name the chain)",
                     )?;
                     if save_shell_input.trim() == "n" {
                         break;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -9,9 +9,10 @@ use async_openai::{
     config::OpenAIConfig,
     types::{
         ChatCompletionRequestUserMessageArgs,
-        CreateChatCompletionRequestArgs, CreateChatCompletionResponse, ResponseFormat,
+        CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
     },
 };
+use surfing::extract_json_to_string;
 use tokio::runtime::Runtime;
 
 #[derive(Debug, Clone)]
@@ -45,7 +46,6 @@ impl LLM {
         let result: String = runtime.block_on(async {
             let request: CreateChatCompletionRequest = CreateChatCompletionRequestArgs::default()
                 .model(&self.model)
-                .response_format(ResponseFormat::JsonObject)
                 .messages(context)
                 .build()?;
 
@@ -58,7 +58,7 @@ impl LLM {
                 };
 
             if let Some(content) = response.choices[0].clone().message.content {
-                return Ok(content);
+                return Ok(extract_json_to_string(&content).unwrap());
             }
 
             return Err(anyhow!("No response is retrieved from the LLM"));


### PR DESCRIPTION
Add surfing crate and simplify LLM response handling

- Add surfing v0.1.1 dependency
- Remove ResponseFormat::JsonObject requirement
- Use extract_json_to_string for response content parsing
- It allows the program to support models which are not natively json output ready, such as the reasoning models. 